### PR TITLE
Fix error message in som.py by completing the renaming of the displayCol...

### DIFF
--- a/Destin/Bindings/Python/som.py
+++ b/Destin/Bindings/Python/som.py
@@ -242,8 +242,8 @@ def som_click_callback(event, x, y, flag, param):
 
         image_index = coords_to_image_index[min_bmu_coords]
         print "BMU X: %i Y:%i, Image index: %i" % (min_bmu_coords[0], min_bmu_coords[1], image_index )
-        cs.displayCifarColorImage(image_index)
-        cs.displayCifarGrayImage(image_index)
+        cs.displayColorImage(image_index)
+        cs.displayGrayImage(image_index)
                 
                 
 

--- a/Destin/Common/ImageSourceBase.h
+++ b/Destin/Common/ImageSourceBase.h
@@ -168,7 +168,7 @@ public:
       */
     void displayColorImage(int image_id, int rows=-1, int cols=-1, string window_title="Color Image"){
         if(image_id < 0 || image_id >= nImages){
-            printf("displayCifarColorImage, index out of bounds\n");
+            printf("displayColorImage, index out of bounds\n");
             return;
         }
 
@@ -176,11 +176,11 @@ public:
         cv::imshow(window_title, bigger);
     }
 
-    /** Same as displayCifarColorImage method, except in grayscale
+    /** Same as displayColorImage method, except in grayscale
       */
     void displayGrayImage(int image_id, int rows=-1, int cols=-1, string window_title="Gray Image"){
         if(image_id < 0 || image_id >= nImages){
-            printf("displayCifarGrayImage, index out of bounds\n");
+            printf("displayGrayImage, index out of bounds\n");
             return;
         }
 


### PR DESCRIPTION
...orImage and displayGrayImage classes that were updated in commit 9008077ae450782a1047ce057cde0f287f3763c3

(Before this fix, som.py throws an AttributeError in the SWIG bindings when you click on one of the dots in the SOM due to the class name not being found)
