### PR TITLE
update valid cmake versions; issue #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See Windows build instructions at https://github.com/opencog/destin/blob/master/
 
 Dependencies:
 
-* CMake (>= 2.8)
+* CMake (2.8.x, >= 3.2)
 * OpenCV 2 (libopencv-dev)
 
 Java Bindings: JDK, ant and SWIG 2.x


### PR DESCRIPTION
It seems there is a bug in version in cmake-3.0.x distributions makes it doesn't work with SWIG,
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=772631

More info #16